### PR TITLE
Update jdbot.js

### DIFF
--- a/jdbot.js
+++ b/jdbot.js
@@ -27,6 +27,7 @@ login_then_run_bot({hash:     process.env.JDBOT_HASH,
                    });
 
 // OR (B) as a shortcut, call run_bot() with your full hash+sid cookie (as shown when you use login_then_run_bot()) to skip the login step:
+// var first_login = true;
 // cookie = 'hash=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef; connect.sid=s%3AAAAAAAAAAAAAAAAAAAAAAAAA.AAAAAAAAAAAAAA%AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 // run_bot(cookie);
 


### PR DESCRIPTION
When using the shortcut method (B) of call run_bot(), the first_login var doesn't get set to true.